### PR TITLE
runner: add DBConnFunc hook for custom DB connections

### DIFF
--- a/pkg/runner/archive_runner.go
+++ b/pkg/runner/archive_runner.go
@@ -47,6 +47,7 @@ type ArchiveRunner struct {
 	fileSizeInBytes uint64
 	startTime       time.Time
 	dryRun          bool
+	dbConnFunc      DBConnFunc
 }
 
 type ArchiveRunnerConfig struct {
@@ -64,6 +65,7 @@ type ArchiveRunnerConfig struct {
 	Password        string
 	FileSizeInBytes uint64
 	DryRun          bool
+	DBConnFunc      DBConnFunc
 }
 type ConfigLoader func(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error)
 
@@ -84,6 +86,7 @@ func NewArchiveRunner(acfg *ArchiveRunnerConfig, logger *logrus.Logger) (*Archiv
 		lockWaitTimeout: acfg.LockWaitTimeout,
 		fileSizeInBytes: acfg.FileSizeInBytes,
 		dryRun:          acfg.DryRun,
+		dbConnFunc:      acfg.DBConnFunc,
 	}, nil
 }
 
@@ -210,7 +213,11 @@ func (ar *ArchiveRunner) setupDBAndCheckIfRunSucceeded(ctx context.Context) (boo
 		Database: ar.database,
 	})
 	dbconfig := setupDBConfig(&DBConfig{Threads: ar.threads, LockWaitTimeout: ar.lockWaitTimeout})
-	ar.db, err = setupDB(ar.dsn, dbconfig)
+	if ar.dbConnFunc != nil {
+		ar.db, err = ar.dbConnFunc(ar.dsn, dbconfig)
+	} else {
+		ar.db, err = setupDB(ar.dsn, dbconfig)
+	}
 	if err != nil {
 		return false, err
 	}

--- a/pkg/runner/db_helper.go
+++ b/pkg/runner/db_helper.go
@@ -8,6 +8,12 @@ import (
 	"github.com/block/spirit/pkg/dbconn"
 )
 
+// DBConnFunc is an optional callback that returns a *sql.DB for the given DSN
+// and config. When nil, the default dbconn.New() path is used. This allows
+// callers to inject a custom *sql.DB (e.g. with tracing)
+// without adding extra dependencies to the OSS library.
+type DBConnFunc func(dsn string, dbConfig *dbconn.DBConfig) (*sql.DB, error)
+
 // DBCreds is a struct to hold database credentials that's common to both stage and archive runners.
 type DBCreds struct {
 	Host     string `name:"host" help:"Hostname" optional:"" default:"127.0.0.1:3306"`

--- a/pkg/runner/db_helper_test.go
+++ b/pkg/runner/db_helper_test.go
@@ -1,0 +1,160 @@
+package runner
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/siddontang/loggers"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLogger() loggers.Advanced {
+	return logrus.New()
+}
+
+func newTestLogrus() *logrus.Logger {
+	return logrus.New()
+}
+
+func TestDBConnFuncType(t *testing.T) {
+	// Verify that DBConnFunc has the correct signature and can be assigned.
+	var fn DBConnFunc
+	assert.Nil(t, fn, "zero-value DBConnFunc should be nil")
+
+	fn = func(dsn string, cfg *dbconn.DBConfig) (*sql.DB, error) {
+		return nil, nil
+	}
+	assert.NotNil(t, fn)
+}
+
+func TestStageRunnerConfig_DBConnFuncNilByDefault(t *testing.T) {
+	cfg := &StageRunnerConfig{}
+	assert.Nil(t, cfg.DBConnFunc, "DBConnFunc should be nil by default for backward compatibility")
+}
+
+func TestArchiveRunnerConfig_DBConnFuncNilByDefault(t *testing.T) {
+	cfg := &ArchiveRunnerConfig{}
+	assert.Nil(t, cfg.DBConnFunc, "DBConnFunc should be nil by default for backward compatibility")
+}
+
+func TestNewStageRunner_StoresDBConnFunc(t *testing.T) {
+	called := false
+	fn := func(dsn string, cfg *dbconn.DBConfig) (*sql.DB, error) {
+		called = true
+		return nil, nil
+	}
+
+	sr, err := NewStageRunner(&StageRunnerConfig{
+		DBConnFunc:      fn,
+		TargetChunkTime: 1,
+	}, newTestLogger())
+	require.NoError(t, err)
+	require.NotNil(t, sr)
+	assert.NotNil(t, sr.dbConnFunc, "dbConnFunc should be stored on StageRunner")
+
+	// Call it to verify it's the same function
+	_, _ = sr.dbConnFunc("", nil)
+	assert.True(t, called)
+}
+
+func TestNewStageRunner_NilDBConnFunc(t *testing.T) {
+	sr, err := NewStageRunner(&StageRunnerConfig{
+		TargetChunkTime: 1,
+	}, newTestLogger())
+	require.NoError(t, err)
+	require.NotNil(t, sr)
+	assert.Nil(t, sr.dbConnFunc, "dbConnFunc should be nil when not provided")
+}
+
+func TestNewArchiveRunner_StoresDBConnFunc(t *testing.T) {
+	called := false
+	fn := func(dsn string, cfg *dbconn.DBConfig) (*sql.DB, error) {
+		called = true
+		return nil, nil
+	}
+
+	ar, err := NewArchiveRunner(&ArchiveRunnerConfig{
+		DBConnFunc: fn,
+	}, newTestLogrus())
+	require.NoError(t, err)
+	require.NotNil(t, ar)
+	assert.NotNil(t, ar.dbConnFunc, "dbConnFunc should be stored on ArchiveRunner")
+
+	_, _ = ar.dbConnFunc("", nil)
+	assert.True(t, called)
+}
+
+func TestNewArchiveRunner_NilDBConnFunc(t *testing.T) {
+	ar, err := NewArchiveRunner(&ArchiveRunnerConfig{}, newTestLogrus())
+	require.NoError(t, err)
+	require.NotNil(t, ar)
+	assert.Nil(t, ar.dbConnFunc, "dbConnFunc should be nil when not provided")
+}
+
+func TestDBConnFunc_ReceivesCorrectArgs(t *testing.T) {
+	var receivedDSN string
+	var receivedConfig *dbconn.DBConfig
+
+	fn := func(dsn string, cfg *dbconn.DBConfig) (*sql.DB, error) {
+		receivedDSN = dsn
+		receivedConfig = cfg
+		return nil, errors.New("test: not a real db")
+	}
+
+	sr, err := NewStageRunner(&StageRunnerConfig{
+		DBConnFunc:      fn,
+		Host:            "myhost:3306",
+		Username:        "myuser",
+		Password:        "mypass",
+		Database:        "mydb",
+		Threads:         8,
+		LockWaitTimeout: 30,
+		TargetChunkTime: 1,
+	}, newTestLogger())
+	require.NoError(t, err)
+
+	// Call setupDBAndCheckIfRunSucceeded which will invoke dbConnFunc
+	_, _ = sr.setupDBAndCheckIfRunSucceeded(t.Context())
+
+	expectedDSN := "myuser:mypass@tcp(myhost:3306)/mydb"
+	assert.Equal(t, expectedDSN, receivedDSN, "DBConnFunc should receive the constructed DSN")
+	assert.NotNil(t, receivedConfig, "DBConnFunc should receive the dbconn config")
+	assert.Equal(t, 9, receivedConfig.MaxOpenConnections, "MaxOpenConnections should be threads+1")
+}
+
+func TestDBConnFunc_ErrorPropagated(t *testing.T) {
+	expectedErr := errors.New("custom connection error")
+	fn := func(dsn string, cfg *dbconn.DBConfig) (*sql.DB, error) {
+		return nil, expectedErr
+	}
+
+	sr, err := NewStageRunner(&StageRunnerConfig{
+		DBConnFunc:      fn,
+		TargetChunkTime: 1,
+	}, newTestLogger())
+	require.NoError(t, err)
+
+	_, err = sr.setupDBAndCheckIfRunSucceeded(t.Context())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestDBConnFunc_ArchiveRunner_ErrorPropagated(t *testing.T) {
+	expectedErr := errors.New("custom archive connection error")
+	fn := func(dsn string, cfg *dbconn.DBConfig) (*sql.DB, error) {
+		return nil, expectedErr
+	}
+
+	ar, err := NewArchiveRunner(&ArchiveRunnerConfig{
+		DBConnFunc: fn,
+	}, newTestLogrus())
+	require.NoError(t, err)
+
+	_, err = ar.setupDBAndCheckIfRunSucceeded(t.Context())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+}

--- a/pkg/runner/stage_runner.go
+++ b/pkg/runner/stage_runner.go
@@ -61,6 +61,7 @@ type StageRunner struct {
 	host            string
 	username        string
 	password        string
+	dbConnFunc      DBConnFunc
 }
 
 type StageRunnerConfig struct {
@@ -79,6 +80,7 @@ type StageRunnerConfig struct {
 	Host            string
 	Username        string
 	Password        string
+	DBConnFunc      DBConnFunc
 }
 
 func NewStageRunner(s *StageRunnerConfig, logger loggers.Advanced) (*StageRunner, error) {
@@ -105,6 +107,7 @@ func NewStageRunner(s *StageRunnerConfig, logger loggers.Advanced) (*StageRunner
 		targetChunkTime: s.TargetChunkTime,
 		logger:          logger,
 		dryrun:          s.DryRun,
+		dbConnFunc:      s.DBConnFunc,
 	}, nil
 }
 
@@ -482,11 +485,19 @@ func (sr *StageRunner) setupDBAndCheckIfRunSucceeded(ctx context.Context) (bool,
 		Database: sr.database,
 	})
 	dbconfig := setupDBConfig(&DBConfig{Threads: sr.threads, LockWaitTimeout: sr.lockWaitTimeout})
-	sr.db, err = setupDB(sr.dsn, dbconfig)
+	if sr.dbConnFunc != nil {
+		sr.db, err = sr.dbConnFunc(sr.dsn, dbconfig)
+	} else {
+		sr.db, err = setupDB(sr.dsn, dbconfig)
+	}
 	if err != nil {
 		return false, fmt.Errorf("error setting up db: %w", err)
 	}
-	sr.replicaDB, err = setupReplicaDB(dbconfig, sr.replicaDSN)
+	if sr.dbConnFunc != nil && sr.replicaDSN != "" {
+		sr.replicaDB, err = sr.dbConnFunc(sr.replicaDSN, dbconfig)
+	} else {
+		sr.replicaDB, err = setupReplicaDB(dbconfig, sr.replicaDSN)
+	}
 	if err != nil {
 		return false, fmt.Errorf("error setting up replica-db: %w", err)
 	}


### PR DESCRIPTION
## Summary

Add an optional `DBConnFunc` callback to `StageRunnerConfig` and `ArchiveRunnerConfig` that lets callers inject a custom `*sql.DB` (e.g. with Datadog APM tracing) without adding tracing dependencies to the OSS library.

When nil (the default), the existing `dbconn.New()` path is used, preserving full backward compatibility.

## Motivation

Services that embed polt may need to instrument MySQL connections with tracing. Without a hook, the only option is to fork or modify the OSS library to add tracing imports — which would pull tracing dependencies into the OSS project.

This hook keeps the tracing concern in the caller while giving it full control over how `*sql.DB` instances are created.

## Changes

- **`db_helper.go`**: Define `DBConnFunc` type
- **`stage_runner.go`**: Add `DBConnFunc` to config/struct, use it in `setupDBAndCheckIfRunSucceeded()` for both primary and replica DB connections
- **`archive_runner.go`**: Same pattern for archive runner
- **`db_helper_test.go`** (new): 10 unit tests covering type assignability, nil-by-default backward compat, storage on both runners, correct DSN/config passthrough, and error propagation

## Testing

All new unit tests pass without requiring a live MySQL instance. Full package builds cleanly.