### PR TITLE
Bump spirit to @main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/block/spirit v0.14.1-0.20260612140803-de986e9f6cbb
+	github.com/block/spirit v0.15.1-0.20260617235652-98a38a253173
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.9 h1:BRVDbewN6VZcwr+FBOszDKvYeXY1
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.9/go.mod h1:f6vjfZER1M17Fokn0IzssOTMT2N8ZSq+7jnNF0tArvw=
 github.com/aws/smithy-go v1.22.1 h1:/HPHZQ0g7f4eUeK6HKglFz8uwVfZKgoI25rb/J+dnro=
 github.com/aws/smithy-go v1.22.1/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
-github.com/block/spirit v0.14.1-0.20260612140803-de986e9f6cbb h1:+Cov6Y+KgZgyadoFPGl20G4Vl/xex0TXQdt0rA1uT2g=
-github.com/block/spirit v0.14.1-0.20260612140803-de986e9f6cbb/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
+github.com/block/spirit v0.15.1-0.20260617235652-98a38a253173 h1:+wbB4brtVUflISkTJsAnkzY+Xw8lTrIvTS3yvanpfN0=
+github.com/block/spirit v0.15.1-0.20260617235652-98a38a253173/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
Bumps `github.com/block/spirit` to the latest `main` commit ([`98a38a2`](https://github.com/block/spirit/commit/98a38a253173)).

```
github.com/block/spirit v0.14.1-0.20260612140803-de986e9f6cbb
  => v0.15.1-0.20260617235652-98a38a253173
```

Routine dependency bump (`go get github.com/block/spirit@main` + `go mod tidy`). Only `go.mod`/`go.sum` change; `go build ./...` passes locally.

🤖 Generated by an automated dependency-bump task on behalf of @mtocker.