### PR TITLE
Bump spirit to @main (adopt AdvisoryLock rename)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/block/spirit v0.15.2-0.20260717204329-9dd2b80e44ca
+	github.com/block/spirit v0.15.2-0.20260722224152-19ef8b5047ed
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.9 h1:BRVDbewN6VZcwr+FBOszDKvYeXY1
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.9/go.mod h1:f6vjfZER1M17Fokn0IzssOTMT2N8ZSq+7jnNF0tArvw=
 github.com/aws/smithy-go v1.22.1 h1:/HPHZQ0g7f4eUeK6HKglFz8uwVfZKgoI25rb/J+dnro=
 github.com/aws/smithy-go v1.22.1/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
-github.com/block/spirit v0.15.2-0.20260717204329-9dd2b80e44ca h1:oVtH8EUC1qqvFlOZVwuITqIx5qooRFULFWYAdAsWfb4=
-github.com/block/spirit v0.15.2-0.20260717204329-9dd2b80e44ca/go.mod h1:NeJcaVY5Sfwd11iDgR3hz8aYB9XSLSxfGTguu9Wj2Dg=
+github.com/block/spirit v0.15.2-0.20260722224152-19ef8b5047ed h1:ofmBHsjEYnE+DO425H15uoWBbt8tBusUMx2xyNHxaxM=
+github.com/block/spirit v0.15.2-0.20260722224152-19ef8b5047ed/go.mod h1:NeJcaVY5Sfwd11iDgR3hz8aYB9XSLSxfGTguu9Wj2Dg=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/pkg/runner/archive_runner.go
+++ b/pkg/runner/archive_runner.go
@@ -27,7 +27,7 @@ const archiveMode = "archive"
 type ArchiveRunner struct {
 	archiver archive.Archiver
 	db       *sql.DB
-	lock     *dbconn.MetadataLock
+	lock     *dbconn.AdvisoryLock
 	// Attached logger
 	logger loggers.Advanced
 
@@ -264,7 +264,7 @@ func (ar *ArchiveRunner) boot(ctx context.Context) (*boot.ArchiveBooter, error) 
 	}
 	// Get advisory lock on the table, this will be unlocked in Close() method.
 	dbConfig := dbconn.NewDBConfig()
-	ar.lock, err = dbconn.NewMetadataLock(ctx, ar.dsn, []*table.TableInfo{ab.SrcTbl}, dbConfig, slog.Default())
+	ar.lock, err = dbconn.NewAdvisoryLock(ctx, ar.dsn, []*table.TableInfo{ab.SrcTbl}, dbConfig, slog.Default())
 	if err != nil {
 		return nil, fmt.Errorf("failed to acquire advisory lock for staging: %w", err)
 	}

--- a/pkg/runner/stage_runner.go
+++ b/pkg/runner/stage_runner.go
@@ -40,7 +40,7 @@ type StageRunner struct {
 	replicaDSN    string
 	replicaDB     *sql.DB
 	stager        *stage.Stager
-	lock          *dbconn.MetadataLock
+	lock          *dbconn.AdvisoryLock
 	runID         string
 	startedBy     string
 	table         string
@@ -316,7 +316,7 @@ func (sr *StageRunner) setStager(ctx context.Context, sb *boot.StageBooter) erro
 
 		// It could be in running state if the previous run failed before marking the run as failed, possibly due to
 		// DB connection failure.
-		// As we acquire the metadata lock on the table prior to this, we can safely assume that the previous run is not running.
+		// As we acquire the advisory lock on the table prior to this, we can safely assume that the previous run is not running.
 	case Failed.String(), Running.String(), Started.String():
 		chkpnt, tryNum, err = sr.getChkPtAndTryNumForResume(ctx, run)
 		if err != nil {
@@ -411,7 +411,7 @@ func (sr *StageRunner) boot(ctx context.Context) (*boot.StageBooter, error) {
 	// This is the same lock acquired by Spirit when running migrations, so that we prevent migrations and archives running at same time on the same table.
 	// see: https://github.com/block/spirit/blob/c3968034254052c56a4ee7f07eced13cabfa2b1a/pkg/migration/runner.go#L205
 	dbConfig := dbconn.NewDBConfig()
-	sr.lock, err = dbconn.NewMetadataLock(ctx, sr.dsn, []*table.TableInfo{srcTbl}, dbConfig, slog.Default())
+	sr.lock, err = dbconn.NewAdvisoryLock(ctx, sr.dsn, []*table.TableInfo{srcTbl}, dbConfig, slog.Default())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runner/stage_runner_test.go
+++ b/pkg/runner/stage_runner_test.go
@@ -357,7 +357,7 @@ func TestResumeFromCheckpoint(t *testing.T) {
 			// Cancel the stager forcefully as soon as we notice data in checkpoints table
 			if test.TableExists(t, auditDB, checkpointsTbl, db) && test.GetCount(t, db, "polt.checkpoints_runid", "1=1") > 0 &&
 				test.GetCount(t, db, "polt.runs", "run_id='runid'") > 0 {
-				// Check that the metadata lock with table name exists while stage runner is running.
+				// Check that the advisory lock with table name exists while stage runner is running.
 				assert.True(t, test.LockExists(t, db, "sr_cpt1"))
 				cancel()
 
@@ -555,7 +555,7 @@ func TestResumeFromDBFailure(t *testing.T) {
 			// Fail the stager forcefully as soon as we notice data in checkpoints table
 			if test.TableExists(t, auditDB, checkpointsTbl, db) && test.GetCount(t, db, "polt.checkpoints_runid2", "1=1") > 0 &&
 				test.GetCount(t, db, "polt.runs", "run_id='runid2'") > 0 {
-				// Check that the metadata lock with table name exists while stage runner is running.
+				// Check that the advisory lock with table name exists while stage runner is running.
 				assert.True(t, test.LockExists(t, db, "sr_cpt2"))
 				// Simulate DB failure and stage failure by closing the connection.
 				_ = s.db.Close() // Ignore error during cleanup

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -104,7 +104,7 @@ func TableExists(t *testing.T, schema, table string, db *sql.DB) bool {
 
 func LockExists(t *testing.T, db *sql.DB, tableName string) bool {
 	t.Helper()
-	var lock *dbconn.MetadataLock
+	var lock *dbconn.AdvisoryLock
 	defer func() {
 		// Release the lock
 		if lock != nil {
@@ -120,7 +120,7 @@ func LockExists(t *testing.T, db *sql.DB, tableName string) bool {
 	// Try to get advisory lock on the table, if there is an error then the lock already exists
 	dbConfig := dbconn.NewDBConfig()
 	logger := slog.Default()
-	lock, err = dbconn.NewMetadataLock(context.Background(), DSN(), []*table.TableInfo{srcTbl}, dbConfig, logger)
+	lock, err = dbconn.NewAdvisoryLock(context.Background(), DSN(), []*table.TableInfo{srcTbl}, dbConfig, logger)
 
 	return err != nil
 }


### PR DESCRIPTION
Bumps `github.com/block/spirit` to the latest `main` (`19ef8b5`, 2026-07-22).

### metadatalock API rename (block/spirit#1067)
Spirit renamed its dbconn advisory-lock API:
- `MetadataLock` → `AdvisoryLock`
- `NewMetadataLock` → `NewAdvisoryLock`

Updated the 3 call sites / field declarations in `pkg/runner/{archive_runner,stage_runner}.go` and `pkg/test/test.go`, plus the related log and comment wording ("metadata lock" → "advisory lock").

### Toolchain
spirit@main requires `go >= 1.26.5`; this repo hermit toolchain was pinned at 1.26.1, so this PR also bumps the hermit Go toolchain to 1.26.5 (`bin/go`, `bin/gofmt`, `.go-*.pkg`) and the `go` directive in go.mod.

Verified with `go build ./...` and `go vet ./...`.

Automated by the recurring bump-all-spirit task.
