### PR TITLE
Bump spirit to @main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/block/spirit v0.15.2-0.20260722224152-19ef8b5047ed
+	github.com/block/spirit v0.15.2-0.20260727035859-220f8b6cfca1
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 )
 

--- a/go.mod
+++ b/go.mod
@@ -75,3 +75,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// TEMP(2026-07): pin fork for JSON render-fidelity fixes; remove once upstream go-mysql includes the formatMySQLDouble + zero-temporal opaque fixes.
+replace github.com/go-mysql-org/go-mysql => github.com/morgo/go-mysql v1.16.1-0.20260723231236-3aced1dddcf4

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.9 h1:BRVDbewN6VZcwr+FBOszDKvYeXY1
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.9/go.mod h1:f6vjfZER1M17Fokn0IzssOTMT2N8ZSq+7jnNF0tArvw=
 github.com/aws/smithy-go v1.22.1 h1:/HPHZQ0g7f4eUeK6HKglFz8uwVfZKgoI25rb/J+dnro=
 github.com/aws/smithy-go v1.22.1/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
-github.com/block/spirit v0.15.2-0.20260722224152-19ef8b5047ed h1:ofmBHsjEYnE+DO425H15uoWBbt8tBusUMx2xyNHxaxM=
-github.com/block/spirit v0.15.2-0.20260722224152-19ef8b5047ed/go.mod h1:NeJcaVY5Sfwd11iDgR3hz8aYB9XSLSxfGTguu9Wj2Dg=
+github.com/block/spirit v0.15.2-0.20260727035859-220f8b6cfca1 h1:XQKA14r8Fuhb8A5La5qjY7PXfpmjsFkO9nQ4Hownykw=
+github.com/block/spirit v0.15.2-0.20260727035859-220f8b6cfca1/go.mod h1:eSX+yt8Ukl+v7ZMNLuVbBreM+2X4gDnR+ree6rLM6tQ=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
Bumps `github.com/block/spirit` to the latest `main` (`v0.15.2-0.20260727035859-220f8b6cfca1`, block/spirit#1086).

- `go get github.com/block/spirit@main && go mod tidy`
- No source changes were needed — no breaking spirit API changes in this range.
- Also adds the temporary `go-mysql` fork pin required alongside spirit bumps:
  `replace github.com/go-mysql-org/go-mysql => github.com/morgo/go-mysql v1.16.1-0.20260723231236-3aced1dddcf4`
  (JSON render-fidelity: `formatMySQLDouble` + zero-temporal opaque fixes; to be removed once these land upstream).
- Verified with `go build ./...` and `go vet ./...` (vet type-checks test files too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Note: the pin is inert for polt today — no polt package imports go-mysql (it enters the module graph only via spirit), so `go.sum` is unchanged. Added for fleet consistency.