### PR TITLE
Bump spirit to @main (e94e99be2c1b)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/block/polt
 go 1.26.5
 
 require (
-	github.com/alecthomas/kong v1.15.0
+	github.com/alecthomas/kong v1.16.0
 	github.com/apache/arrow-go/v18 v18.1.0
 	github.com/aws/aws-sdk-go-v2 v1.33.0
 	github.com/aws/aws-sdk-go-v2/config v1.29.1
@@ -18,7 +18,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/block/spirit v0.15.2-0.20260722224152-19ef8b5047ed
+	github.com/block/spirit v0.15.2-0.20260731132010-e94e99be2c1b
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvK
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/kong v1.15.0 h1:BVJstKbpO73zKpmIu+m/aLRrNmWwxXPIGTNin9VmLVI=
-github.com/alecthomas/kong v1.15.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
+github.com/alecthomas/kong v1.16.0 h1:g92/kUxBcdcTPOM79yE63viJgtcp5dNyrB3/O2cjYT4=
+github.com/alecthomas/kong v1.16.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
@@ -50,8 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.9 h1:BRVDbewN6VZcwr+FBOszDKvYeXY1
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.9/go.mod h1:f6vjfZER1M17Fokn0IzssOTMT2N8ZSq+7jnNF0tArvw=
 github.com/aws/smithy-go v1.22.1 h1:/HPHZQ0g7f4eUeK6HKglFz8uwVfZKgoI25rb/J+dnro=
 github.com/aws/smithy-go v1.22.1/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
-github.com/block/spirit v0.15.2-0.20260722224152-19ef8b5047ed h1:ofmBHsjEYnE+DO425H15uoWBbt8tBusUMx2xyNHxaxM=
-github.com/block/spirit v0.15.2-0.20260722224152-19ef8b5047ed/go.mod h1:NeJcaVY5Sfwd11iDgR3hz8aYB9XSLSxfGTguu9Wj2Dg=
+github.com/block/spirit v0.15.2-0.20260731132010-e94e99be2c1b h1:Eimx5kTnpoxXKjl42PSPIvWIIJEDIxq8Y1bAiVxdYQU=
+github.com/block/spirit v0.15.2-0.20260731132010-e94e99be2c1b/go.mod h1:+ztqAd6YaMx844cr3/GnxWh+vqyOBHHApW7eAg92BW0=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
Routine dependency bump: `github.com/block/spirit` → `main` (`e94e99be2c1b`, 2026-07-31).

`go get github.com/block/spirit@main && go mod tidy`. No source changes were needed — spirit's API is compatible as consumed here. The hermit-pinned Go toolchain was already at 1.26.5, so no toolchain rebuild was required.

`go mod tidy` also picked up `github.com/alecthomas/kong` v1.15.0 → v1.16.0 transitively.

Verified with `./bin/go build ./...` and `./bin/go vet ./...` (vet type-checks test files too, so stale API use in tests would have surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
