### PR TITLE
Bump spirit to @main (9d6bdd67a9e1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/block/spirit v0.15.2-0.20260731132010-e94e99be2c1b
+	github.com/block/spirit v0.15.2-0.20260731194359-9d6bdd67a9e1
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.9 h1:BRVDbewN6VZcwr+FBOszDKvYeXY1
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.9/go.mod h1:f6vjfZER1M17Fokn0IzssOTMT2N8ZSq+7jnNF0tArvw=
 github.com/aws/smithy-go v1.22.1 h1:/HPHZQ0g7f4eUeK6HKglFz8uwVfZKgoI25rb/J+dnro=
 github.com/aws/smithy-go v1.22.1/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
-github.com/block/spirit v0.15.2-0.20260731132010-e94e99be2c1b h1:Eimx5kTnpoxXKjl42PSPIvWIIJEDIxq8Y1bAiVxdYQU=
-github.com/block/spirit v0.15.2-0.20260731132010-e94e99be2c1b/go.mod h1:+ztqAd6YaMx844cr3/GnxWh+vqyOBHHApW7eAg92BW0=
+github.com/block/spirit v0.15.2-0.20260731194359-9d6bdd67a9e1 h1:qXf7geE+YEn9PnPsRVRj/hpGstNC/d5KnMjPg2m6pqk=
+github.com/block/spirit v0.15.2-0.20260731194359-9d6bdd67a9e1/go.mod h1:aR9KJ8sca3Lo5IpwH6ZGRqK2zdl4Ukhuh7jNdBCRdDk=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
## What

Bumps `github.com/block/spirit` to latest `main`:

- to `v0.15.2-0.20260731194359-9d6bdd67a9e1`

## Note on the go-mysql pin

[block/spirit#1107](https://github.com/block/spirit/pull/1107) dropped spirit's
`replace github.com/go-mysql-org/go-mysql => github.com/morgo/go-mysql`
directive and now requires upstream `go-mysql-org/go-mysql
v1.16.1-0.20260731133054-6f853f178dc3` directly. Sibling repos that carried a
matching local `replace` (gap, gap-ski, ods-shift-v2, strata, schemabot) drop it
in their own bump PRs. polt never carried one — go-mysql reaches polt only
through spirit's module graph — so there is nothing to remove here.

## Verification

```
$ ./bin/go list -m github.com/go-mysql-org/go-mysql
github.com/go-mysql-org/go-mysql v1.16.1-0.20260731133054-6f853f178dc3
```

`./bin/go build ./...` and `./bin/go vet ./...` clean. Hermit go is already
1.26.5, satisfying spirit's `go` directive — no toolchain rebuild needed.

Only `go.mod` / `go.sum` changed; no code changes were required by this bump.